### PR TITLE
Suppress warnings on `const`

### DIFF
--- a/linters/jshintrc
+++ b/linters/jshintrc
@@ -77,5 +77,8 @@
   "-W035": true,
 
   // Suppress warnings about redefining parameters
-  "-W004": true
+  "-W004": true,
+  
+  // Allow ES.next specific features such as `const`
+  "esnext" true
 }


### PR DESCRIPTION
See http://jshint.com/docs/options/#esnext

This also allows other ES6 keywords (e.g, `let`).
