### PR TITLE
Require all function arguments to be used in the function

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -94,7 +94,7 @@ rules:
   no-underscore-dangle: 0
   no-unreachable: 2
   no-unused-expressions: 2
-  no-unused-vars: [2, {vars: 'all', args: 'after-used'}]
+  no-unused-vars: [2, {vars: 'all', args: 'all'}]
   no-use-before-define: 2
   no-void: 2
   no-var: 2


### PR DESCRIPTION
The motivation for `after-used` is to help deal with cases where you have a function being used as a callback and you don't need to use all the parameters that the callback takes. Javascript allows you to ignore arguments from the right by just making the function signature shorter, but there is no built-in way to chop off arguments from the left.

However, I think this is a rare enough problem that the benefits of making this stricter outweigh the costs. When we do have this problem, there is a fairly nice solution. Say we want `f` to be a callback function that takes 4 parameters, but we only care about the third. Then we can do the following, which is very explicit and does not generate any eslint errors:

```
function unused() {
  return;
}

function f(a, b, c) {
  unused(a, b);
  return c === 1;
}
```