### PR TITLE
updated naming conventions for 2.0

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -31,7 +31,6 @@ rules:
   no-else-return: 0
   no-empty: 2
   no-empty-character-class: 2
-  no-empty-label: 2
   no-empty-pattern: 2
   no-eq-null: 2
   no-eval: 2
@@ -151,6 +150,7 @@ rules:
   init-declarations: 0
   jsx-quotes: 0
   key-spacing: [2, {beforeColon: false, afterColon: true}]
+  keyword-spacing: 2
   lines-around-comment: 0
   max-depth: [0, 4]
   max-len: [2, 80]
@@ -180,13 +180,10 @@ rules:
   semi: 2
   semi-spacing: 2
   sort-vars: 0
-  space-after-keywords: 2
-  space-before-keywords: 2
   space-before-blocks: 2
   space-before-function-paren: [2, 'never']
   space-in-parens: 2
   space-infix-ops: 2
-  space-return-throw-case: 2
   space-unary-ops: [2, {words: true, nonwords: false}]
   spaced-comment: 2
   strict: [2, 'global']


### PR DESCRIPTION
no-empty-label -> no-labels
space-after-keywords -> keyword-spacing
space-before-keywords -> keyword-spacing
space-return-throw-case -> keyword-spacing