### PR TITLE
Update rules for eslint2

### DIFF
--- a/eslintrc
+++ b/eslintrc
@@ -119,6 +119,7 @@ rules:
   handle-callback-err: 2
   indent: [2, 2, {SwitchCase: 1}]
   key-spacing: [2, {beforeColon: false, afterColon: true}]
+  keyword-spacing: 2
   max-depth: [1, 4]
   max-len: [2, 80]
   max-nested-callbacks: [1, 2]
@@ -134,7 +135,6 @@ rules:
   radix: 2
   semi: 2
   sort-vars: 0
-  space-after-keywords: 2
   space-before-blocks: 2
   space-before-function-paren: [2, 'never']
   object-curly-spacing: [2, 'never']


### PR DESCRIPTION
http://eslint.org/docs/rules/space-after-keywords
> Replacement notice: This rule was removed in ESLint v2.0 and replaced by
keyword-spacing rule.

http://eslint.org/docs/rules/keyword-spacing